### PR TITLE
⚙️ ci(workflows): disable prod announce step for vercel deploy

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -284,7 +284,7 @@ jobs:
       - name: "📢 Announce deployment and favorite frame"
         if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && env.deploy_this == 'true'
         env:
-          deploy_this: true
+          deploy_this: false
           FARCASTER_BEARER_TOKEN: ${{ secrets.FARCASTER_BEARER_TOKEN }}
         run: |
                   PRODUCTION_URL="${{ steps.deploy-production.outputs.production_url }}"


### PR DESCRIPTION
Set the deploy announcement flag to false to prevent posting deployment
announcements and favoriting frames on the Farcaster bot during production
deploys. This avoids duplicate or unwanted notifications from CI.