### PR TITLE
feat(invoice): ✨ add new invoice creation page and update favicons

### DIFF
--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,19 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="12" y1="6" x2="52" y2="58" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#34D399" />
+      <stop offset="1" stop-color="#059669" />
+    </linearGradient>
+    <linearGradient id="doc" x1="24" y1="16" x2="40" y2="48" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F8FAFC" />
+      <stop offset="1" stop-color="#E2E8F0" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="url(#bg)" />
+  <path d="M24 17c0-1.657 1.343-3 3-3h10l7 7v26c0 1.657-1.343 3-3 3H27c-1.657 0-3-1.343-3-3V17Z" fill="url(#doc)" />
+  <path d="M37 14v6c0 1.657 1.343 3 3 3h6" fill="#DCFCE7" />
+  <path d="M22 31h12" stroke="#10B981" stroke-width="2" stroke-linecap="round" />
+  <path d="M22 38h8" stroke="#10B981" stroke-width="2" stroke-linecap="round" />
+  <path d="M30 45h-8" stroke="#10B981" stroke-width="2" stroke-linecap="round" />
+  <path d="M33.75 41.5 38 45.75l8.25-8.25" stroke="#16A34A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/src/app/invoice/new/page.tsx
+++ b/src/app/invoice/new/page.tsx
@@ -1,0 +1,378 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+type InvoiceFormState = {
+  client: string;
+  from: string;
+  description: string;
+  amount: string;
+  currency: string;
+  deadline: string;
+  category: string;
+  cryptoAddress: string;
+  blockchainNetwork: string;
+  paymentLink: string;
+};
+
+const initialState: InvoiceFormState = {
+  client: '',
+  from: '',
+  description: '',
+  amount: '',
+  currency: '',
+  deadline: '',
+  category: 'general',
+  cryptoAddress: '',
+  blockchainNetwork: '',
+  paymentLink: '',
+};
+
+export default function NewInvoicePage() {
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [formState, setFormState] = useState<InvoiceFormState>(initialState);
+  const router = useRouter();
+
+  const handleCreateInvoice = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitted(true);
+    // TODO: integrate with backend or state management for invoice creation
+  };
+
+  const handlePrintInvoice = () => {
+    if (typeof window !== 'undefined') {
+      try {
+        sessionStorage.setItem(
+          'create-invoice-easy:printData',
+          JSON.stringify(formState),
+        );
+      } catch (e) {
+        // Fallback if sessionStorage is not available
+      }
+      router.push('/invoice/print');
+    }
+  };
+
+  const handleChange: React.ChangeEventHandler<
+    HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+  > = (
+    event,
+  ) => {
+    const { name, value } = event.target;
+    setFormState((prev) => ({ ...prev, [name]: value }));
+    if (isSubmitted) {
+      setIsSubmitted(false);
+    }
+  };
+
+  const formattedAmount = useMemo(() => {
+    if (!formState.amount) return '';
+    const amountNumber = Number(formState.amount);
+    if (Number.isNaN(amountNumber)) return formState.amount;
+    return amountNumber.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+  }, [formState.amount]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-emerald-50 via-lime-50 to-green-100 dark:from-slate-900 dark:via-emerald-900 dark:to-emerald-950 p-8">
+      <div className="mx-auto max-w-4xl">
+        <header className="py-12">
+          <h1 className="text-4xl font-bold text-emerald-900 dark:text-emerald-100">
+            Create a New Invoice
+          </h1>
+          <p className="mt-4 text-lg text-emerald-700 dark:text-emerald-300">
+            Fill out the form below to generate a professional invoice for your client.
+          </p>
+        </header>
+
+        <section className="mb-20 rounded-2xl border border-emerald-200 bg-white/80 p-8 shadow-lg backdrop-blur dark:border-emerald-800 dark:bg-emerald-950/60">
+          <form className="space-y-6" onSubmit={handleCreateInvoice}>
+            <div className="grid gap-6 md:grid-cols-2">
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium text-emerald-900 dark:text-emerald-100">
+                  Client Name / Company
+                </span>
+                <input
+                  type="text"
+                  name="client"
+                  required
+                  placeholder="e.g. Acme Corp."
+                  value={formState.client}
+                  onChange={handleChange}
+                  className="rounded-lg border border-emerald-200 bg-white px-4 py-3 text-emerald-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-50"
+                />
+              </label>
+
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium text-emerald-900 dark:text-emerald-100">
+                  From
+                </span>
+                <input
+                  type="text"
+                  name="from"
+                  required
+                  placeholder="Your business name"
+                  value={formState.from}
+                  onChange={handleChange}
+                  className="rounded-lg border border-emerald-200 bg-white px-4 py-3 text-emerald-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-50"
+                />
+              </label>
+            </div>
+
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-emerald-900 dark:text-emerald-100">
+                Invoice Type
+              </span>
+              <select
+                name="category"
+                value={formState.category}
+                onChange={handleChange}
+                className="w-full rounded-lg border border-emerald-200 bg-white px-4 py-3 text-emerald-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-50"
+              >
+                <option value="crypto">Crypto</option>
+                <option value="general">General</option>
+              </select>
+            </label>
+
+            {formState.category === 'crypto' ? (
+              <div className="grid gap-6 md:grid-cols-2">
+                <label className="flex flex-col gap-2">
+                  <span className="text-sm font-medium text-emerald-900 dark:text-emerald-100">
+                    Crypto Address
+                  </span>
+                  <input
+                    type="text"
+                    name="cryptoAddress"
+                    required
+                    placeholder="e.g. 0x..."
+                    value={formState.cryptoAddress}
+                    onChange={handleChange}
+                    className="rounded-lg border border-emerald-200 bg-white px-4 py-3 text-emerald-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-50"
+                  />
+                </label>
+
+                <label className="flex flex-col gap-2">
+                  <span className="text-sm font-medium text-emerald-900 dark:text-emerald-100">
+                    Blockchain Network
+                  </span>
+                  <input
+                    type="text"
+                    name="blockchainNetwork"
+                    required
+                    placeholder="e.g. Ethereum, Solana"
+                    value={formState.blockchainNetwork}
+                    onChange={handleChange}
+                    className="rounded-lg border border-emerald-200 bg-white px-4 py-3 text-emerald-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-50"
+                  />
+                </label>
+              </div>
+            ) : (
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium text-emerald-900 dark:text-emerald-100">
+                  Payment Link
+                </span>
+                <input
+                  type="url"
+                  name="paymentLink"
+                  required
+                  placeholder="https://"
+                  value={formState.paymentLink}
+                  onChange={handleChange}
+                  className="rounded-lg border border-emerald-200 bg-white px-4 py-3 text-emerald-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-50"
+                />
+              </label>
+            )}
+
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-emerald-900 dark:text-emerald-100">
+                Description
+              </span>
+              <textarea
+                name="description"
+                required
+                rows={4}
+                placeholder="Describe the services or products provided"
+                value={formState.description}
+                onChange={handleChange}
+                className="rounded-lg border border-emerald-200 bg-white px-4 py-3 text-emerald-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-50"
+              />
+            </label>
+
+            <div className="grid gap-6 md:grid-cols-2">
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium text-emerald-900 dark:text-emerald-100">
+                  Amount
+                </span>
+                <div className="flex gap-3">
+                  <input
+                    type="number"
+                    name="amount"
+                    required
+                    min="0"
+                    step="0.01"
+                    placeholder="0.00"
+                    value={formState.amount}
+                    onChange={handleChange}
+                    className="w-full rounded-lg border border-emerald-200 bg-white px-4 py-3 text-emerald-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-50"
+                  />
+                  <input
+                    type="text"
+                    name="currency"
+                    required
+                    maxLength={6}
+                    placeholder="Currency (e.g. USD, BTC)"
+                    value={formState.currency}
+                    onChange={handleChange}
+                    className="w-40 rounded-lg border border-emerald-200 bg-white px-4 py-3 uppercase text-emerald-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-50"
+                  />
+                </div>
+              </label>
+
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium text-emerald-900 dark:text-emerald-100">
+                  Deadline
+                </span>
+                <input
+                  type="date"
+                  name="deadline"
+                  required
+                  value={formState.deadline}
+                  onChange={handleChange}
+                  className="rounded-lg border border-emerald-200 bg-white px-4 py-3 text-emerald-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-50"
+                />
+              </label>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-4">
+              <button
+                type="submit"
+                className="rounded-lg bg-emerald-600 px-6 py-3 text-white font-semibold shadow-sm hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+              >
+                Generate Invoice
+              </button>
+              <button
+                type="button"
+                onClick={handlePrintInvoice}
+                className="rounded-lg border border-emerald-600 px-6 py-3 text-emerald-700 font-semibold hover:bg-emerald-50 dark:border-emerald-400 dark:text-emerald-200 dark:hover:bg-emerald-900"
+              >
+                Print PDF
+              </button>
+              <a
+                href="/"
+                className="rounded-lg border border-emerald-600 px-6 py-3 text-emerald-700 font-semibold hover:bg-emerald-50 dark:border-emerald-400 dark:text-emerald-200 dark:hover:bg-emerald-900"
+              >
+                Cancel
+              </a>
+            </div>
+          </form>
+
+          {isSubmitted && (
+            <div className="mt-6 rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-900/60 dark:text-emerald-100">
+              Invoice created successfully! (Demo state — replace with real integration.)
+            </div>
+          )}
+        </section>
+
+        <section className="mb-20 rounded-2xl border border-emerald-300 bg-white/70 p-8 shadow-inner backdrop-blur-sm dark:border-emerald-800 dark:bg-emerald-950/40">
+          <h2 className="text-xl font-semibold text-emerald-900 dark:text-emerald-100">
+            Invoice Preview
+          </h2>
+          <p className="mt-2 text-sm text-emerald-700 dark:text-emerald-300">
+            This preview updates in real-time as you fill out the form above.
+          </p>
+
+          <div className="mt-6 space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-emerald-500 dark:text-emerald-300">
+                  Billed To
+                </p>
+                <p className="mt-1 text-base font-medium text-emerald-900 dark:text-emerald-100">
+                  {formState.client || 'Client name or company'}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide text-emerald-500 dark:text-emerald-300">
+                  From
+                </p>
+                <p className="mt-1 text-base font-medium text-emerald-900 dark:text-emerald-100">
+                  {formState.from || 'Your business name'}
+                </p>
+              </div>
+            </div>
+
+            <div>
+              <p className="text-xs uppercase tracking-wide text-emerald-500 dark:text-emerald-300">
+                Description
+              </p>
+              <p className="mt-1 whitespace-pre-line rounded-lg border border-emerald-100 bg-white/60 p-4 text-emerald-900 shadow-sm dark:border-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-100">
+                {formState.description || 'Describe the services or products provided'}
+              </p>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-emerald-500 dark:text-emerald-300">
+                  Amount Due
+                </p>
+                <p className="mt-1 text-2xl font-semibold text-emerald-900 dark:text-emerald-100">
+                  {formattedAmount ? `${formattedAmount} ${formState.currency || ''}`.trim() : '0.00'}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide text-emerald-500 dark:text-emerald-300">
+                  Deadline
+                </p>
+                <p className="mt-1 text-base font-medium text-emerald-900 dark:text-emerald-100">
+                  {formState.deadline || 'Select a due date'}
+                </p>
+              </div>
+            </div>
+
+            <div>
+              <p className="text-xs uppercase tracking-wide text-emerald-500 dark:text-emerald-300">
+                Invoice Type
+              </p>
+              <p className="mt-1 inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-sm font-medium text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-200">
+                {formState.category === 'crypto' ? 'Crypto' : 'General'}
+              </p>
+            </div>
+
+            {formState.category === 'crypto' ? (
+              <div className="grid gap-4 md:grid-cols-2">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-emerald-500 dark:text-emerald-300">
+                    Crypto Address
+                  </p>
+                  <p className="mt-1 rounded-lg border border-emerald-100 bg-white/60 p-3 text-sm text-emerald-900 shadow-sm dark:border-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-100">
+                    {formState.cryptoAddress || 'Enter a wallet address'}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-emerald-500 dark:text-emerald-300">
+                    Blockchain Network
+                  </p>
+                  <p className="mt-1 rounded-lg border border-emerald-100 bg-white/60 p-3 text-sm text-emerald-900 shadow-sm dark:border-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-100">
+                    {formState.blockchainNetwork || 'Specify the network'}
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div>
+                <p className="text-xs uppercase tracking-wide text-emerald-500 dark:text-emerald-300">
+                  Payment Link
+                </p>
+                <p className="mt-1 break-all rounded-lg border border-emerald-100 bg-white/60 p-3 text-sm text-emerald-900 shadow-sm dark:border-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-100">
+                  {formState.paymentLink || 'Provide a payment URL'}
+                </p>
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/invoice/print/page.tsx
+++ b/src/app/invoice/print/page.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+
+type InvoiceData = {
+  client: string;
+  from: string;
+  description: string;
+  amount: string;
+  currency: string;
+  deadline: string;
+  category: string; // 'crypto' | 'general'
+  cryptoAddress: string;
+  blockchainNetwork: string;
+  paymentLink: string;
+};
+
+export default function PrintInvoicePage() {
+  const [data, setData] = useState<InvoiceData | null>(null);
+
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem("create-invoice-easy:printData");
+      if (raw) {
+        setData(JSON.parse(raw));
+      }
+    } catch (_) {
+      // ignore parsing/storage errors
+    }
+  }, []);
+
+  const formattedAmount = useMemo(() => {
+    if (!data?.amount) return "";
+    const n = Number(data.amount);
+    if (Number.isNaN(n)) return data.amount;
+    return n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }, [data]);
+
+  if (!data) {
+    return (
+      <div className="min-h-screen p-8 flex items-center justify-center bg-emerald-50 dark:bg-emerald-950 print:bg-white print:p-0">
+        <div className="max-w-lg text-center">
+          <h1 className="text-2xl font-semibold text-emerald-900 dark:text-emerald-100">No invoice data found</h1>
+          <p className="mt-2 text-emerald-700 dark:text-emerald-300">
+            Go back to create an invoice, then use the Print PDF button.
+          </p>
+          <div className="mt-6 flex gap-3 justify-center print:hidden">
+            <Link
+              href="/invoice/new"
+              className="rounded-lg bg-emerald-600 px-6 py-3 text-white font-semibold shadow-sm hover:bg-emerald-700"
+            >
+              Back to form
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-emerald-50 dark:bg-emerald-950 p-6 print:bg-white print:p-0">
+      {/* Controls visible only on screen, hidden in printed PDF */}
+      <div className="print:hidden mb-6 flex items-center justify-between">
+        <Link
+          href="/invoice/new"
+          className="rounded-lg border border-emerald-600 px-4 py-2 text-emerald-700 font-medium hover:bg-emerald-50 dark:border-emerald-400 dark:text-emerald-200 dark:hover:bg-emerald-900"
+        >
+          Back to edit
+        </Link>
+        <button
+          type="button"
+          onClick={() => window.print()}
+          className="rounded-lg bg-emerald-600 px-4 py-2 text-white font-semibold shadow-sm hover:bg-emerald-700"
+        >
+          Print again
+        </button>
+      </div>
+
+      <div className="mx-auto max-w-3xl bg-white shadow-lg rounded-xl p-10 border border-emerald-200 print:shadow-none print:rounded-none print:border-0 print:max-w-none print:w-auto">
+        {/* Header */}
+        <div className="flex items-start justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-emerald-900">Invoice</h1>
+            <p className="mt-2 text-emerald-700">
+              Issued by: <span className="font-medium text-emerald-900">{data.from || "Your business"}</span>
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-sm text-emerald-700">Due Date</p>
+            <p className="text-lg font-semibold text-emerald-900">{data.deadline || "—"}</p>
+          </div>
+        </div>
+
+        <hr className="my-8 border-emerald-200" />
+
+        {/* Parties */}
+        <div className="grid gap-6 md:grid-cols-2">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-emerald-500">Billed To</p>
+            <p className="mt-1 text-base font-medium text-emerald-900">{data.client || "Client name or company"}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-emerald-500">From</p>
+            <p className="mt-1 text-base font-medium text-emerald-900">{data.from || "Your business name"}</p>
+          </div>
+        </div>
+
+        {/* Description */}
+        <div className="mt-8">
+          <p className="text-xs uppercase tracking-wide text-emerald-500">Description</p>
+          <p className="mt-2 whitespace-pre-line rounded-lg border border-emerald-100 bg-emerald-50 p-4 text-emerald-900">
+            {data.description || "Describe the services or products provided"}
+          </p>
+        </div>
+
+        {/* Amount */}
+        <div className="mt-8 grid gap-6 md:grid-cols-2">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-emerald-500">Amount Due</p>
+            <p className="mt-2 text-2xl font-semibold text-emerald-900">
+              {formattedAmount ? `${formattedAmount} ${data.currency || ""}`.trim() : "0.00"}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-emerald-500">Invoice Type</p>
+            <p className="mt-2 inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-sm font-medium text-emerald-800">
+              {data.category === "crypto" ? "Crypto" : "General"}
+            </p>
+          </div>
+        </div>
+
+        {/* Conditional payment details */}
+        {data.category === "crypto" ? (
+          <div className="mt-8 grid gap-6 md:grid-cols-2">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-emerald-500">Crypto Address</p>
+              <p className="mt-2 rounded-lg border border-emerald-100 bg-emerald-50 p-3 text-sm text-emerald-900">
+                {data.cryptoAddress || "Enter a wallet address"}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-emerald-500">Blockchain Network</p>
+              <p className="mt-2 rounded-lg border border-emerald-100 bg-emerald-50 p-3 text-sm text-emerald-900">
+                {data.blockchainNetwork || "Specify the network"}
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="mt-8">
+            <p className="text-xs uppercase tracking-wide text-emerald-500">Payment Link</p>
+            <p className="mt-2 break-all rounded-lg border border-emerald-100 bg-emerald-50 p-3 text-sm text-emerald-900">
+              {data.paymentLink || "Provide a payment URL"}
+            </p>
+          </div>
+        )}
+
+        <hr className="my-10 border-emerald-200" />
+        <p className="text-xs text-emerald-600">
+          Thank you for your business. Please submit payment by the due date above.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -89,9 +89,10 @@ export const metadata: Metadata = {
     },
   },
   icons: {
-    icon: '/favicon.ico',
-    shortcut: '/favicon-16x16.png',
-    apple: '/apple-touch-icon.png',
+    icon: [
+      { url: '/icon.svg', type: 'image/svg+xml' },
+    ],
+    shortcut: ['/icon.svg'],
   },
   other: {
     // Farcaster Mini App metadata for sharing

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,10 @@
 'use client';
 
+import Link from 'next/link';
 import { useEffect } from 'react';
 import { sdk } from '@farcaster/miniapp-sdk'
 
 export default function Home() {
-  
-
   useEffect(() => {
     const initializeSdk = async () => {
       await sdk.actions.ready();
@@ -13,25 +12,26 @@ export default function Home() {
     initializeSdk();
   }, []);
 
-
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 p-8">
+    <div className="min-h-screen bg-gradient-to-br from-emerald-50 via-lime-50 to-green-100 dark:from-slate-900 dark:via-emerald-900 dark:to-emerald-950 p-8">
       <div className="max-w-4xl mx-auto">
         <section className="py-20">
           <h1 className="text-4xl sm:text-5xl font-bold text-slate-900 dark:text-white">
             Create Invoice Easy
           </h1>
-          <p className="mt-6 text-lg text-slate-600 dark:text-slate-300">
+          <p className="mt-6 text-lg text-emerald-900 dark:text-emerald-200">
             Craft polished invoices in minutes, track payments effortlessly, and keep your business moving forward with confidence.
           </p>
           <div className="mt-10 flex flex-wrap gap-4">
-            <button className="rounded-lg bg-sky-600 px-6 py-3 text-white font-semibold shadow-sm hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600">
-              Get Started
-            </button>
+            <Link
+              href="/invoice/new"
+              className="rounded-lg bg-emerald-600 px-6 py-3 text-white font-semibold shadow-sm hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+            >
+              Create an Invoice
+            </Link>
             <a
               href="#features"
-              className="rounded-lg border border-sky-600 px-6 py-3 text-sky-700 font-semibold hover:bg-sky-50 dark:border-sky-400 dark:text-sky-300 dark:hover:bg-slate-800"
+              className="rounded-lg border border-emerald-600 px-6 py-3 text-emerald-700 font-semibold hover:bg-emerald-50 dark:border-emerald-400 dark:text-emerald-200 dark:hover:bg-emerald-900"
             >
               View Features
             </a>


### PR DESCRIPTION
Add a client-side new invoice page (src/app/invoice/new/page.tsx) with form state,
validation helpers, print-to-sessionStorage support, and UI for creating invoices.
Also update app icons in layout (src/app/layout.tsx) to use SVG icon arrays
and shortcut entries.

- add invoice form with fields: client, from, description, amount, currency,
  deadline, category, crypto address, blockchain network, payment link
- format amount display and reset submission state on change
- persist form data to sessionStorage for printing and navigate to /invoice/print
- replace single favicon entries with structured icon array and shortcut list

No breaking changes.