### PR TITLE
docs(readme): 📚 overhaul README with app overview and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,74 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Create Invoice Easy
+
+Create Invoice Easy is a Next.js application that helps freelancers and small teams craft polished invoices in minutes. The experience focuses on swift data entry, live previews, and ready-to-print PDFs, all while keeping branding consistent with an emerald-toned interface.
+
+## Features
+
+- **Guided invoice creation** – Collect client, issuer, deadline, and description details with validation directly in `src/app/invoice/new/page.tsx`.
+- **Crypto or traditional payments** – Toggle between wallet fields (address and blockchain network) or a payment URL for general invoices.
+- **Real-time preview** – See invoices update instantly as you type, ensuring formatting tweaks are caught before sharing.
+- **PDF-ready print view** – Store invoice data in session storage and render a printer-friendly layout via `src/app/invoice/print/page.tsx`.
+- **Farcaster mini-app integration** – Initialize the Farcaster Mini App SDK (`@farcaster/miniapp-sdk`) so invoices can launch inside Warpcast.
+- **Accessible Tailwind UI** – Use emerald gradients, high contrast text, and responsive layouts for pleasant usage across devices.
 
 ## Getting Started
 
-First, run the development server:
+1. **Install dependencies**
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+   ```bash
+   pnpm install
+   ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+2. **Run the development server**
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+   ```bash
+   pnpm dev
+   ```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+3. Open [http://localhost:3000](http://localhost:3000) to explore the app.
 
-## Learn More
+> Tip: Update environment variables or API endpoints in `next.config.js` or `.env` files as you integrate backend services.
 
-To learn more about Next.js, take a look at the following resources:
+## Usage
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+1. Navigate to `/invoice/new`.
+2. Enter issuer and client information, invoice description, amount, currency, and deadline.
+3. Select **General** or **Crypto** to reveal the relevant payment fields.
+4. Click **Generate Invoice** to validate the form.
+5. Choose **Print PDF** to view a formatted summary in `/invoice/print` and download or print it.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Farcaster Mini App Notes
 
-## Deploy on Vercel
+- The root page (`src/app/page.tsx`) calls `sdk.actions.ready()` from `@farcaster/miniapp-sdk` to support embedding inside Farcaster.
+- When deploying as a Farcaster mini-app, ensure the application URL is registered and cached per Farcaster requirements.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Project Structure Overview
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- `src/app/page.tsx` – Landing page and Farcaster integration bootstrap.
+- `src/app/invoice/new/page.tsx` – Interactive invoice builder with preview.
+- `src/app/invoice/print/page.tsx` – Printer-friendly invoice renderer.
+- `public/.well-known/farcaster.json` – Farcaster mini-app metadata manifest.
+
+## Tech Stack
+
+- **Framework**: Next.js (App Router)
+- **Styling**: Tailwind CSS with custom emerald palette
+- **State & Storage**: React hooks with session storage bridge for printing
+- **Ecosystem**: Farcaster Mini App SDK for Warpcast compatibility
+
+## Roadmap Ideas
+
+- **[ ]** Persist invoices to a database for retrieval history.
+- **[ ]** Email invoices directly from the print view.
+- **[ ]** Add multi-item line support instead of a single description field.
+
+## Contributing
+
+- **Fork & clone** this repository.
+- Create a feature branch based on `main`.
+- Follow repository linting/testing guidelines (add `pnpm test` when available).
+- Submit a pull request describing the changes and screenshots for UI updates.
+
+## Deployment
+
+Deploy on [Vercel](https://vercel.com/) or your preferred platform. Ensure environment variables and Farcaster metadata are configured before going live.


### PR DESCRIPTION
Expanded README.md to provide a full project overview for "Create Invoice Easy":, getting started, usage, Farcaster-app notes, project structure, tech, roadmap, contributing, and deployment instructions. Replaced starter create-next-app content with detailed guidance, commands, and pointers to invoice pages and Farcaster integration.

No code changes.