### PR TITLE
docs(.env): 📚 add .env to repo and allow committed example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# Copy this file to `.env` and replace placeholder values with your own secrets.
+# Do not commit your real `.env` file.
+
+CLOUDFLARE_ACCOUNT_ID=your-cloudflare-account-id
+CLOUDFLARE_API_TOKEN=your-cloudflare-api-token
+PAT_TOKEN=ghp_your-personal-access-token
+FARCASTER_FID=your-farcaster-fid
+FARCASTER_CUSTODY_ADDRESS=0xyour-farcaster-custody-address
+FARCASTER_CUSTODY_PRIVATE_KEY=0xyour-farcaster-custody-private-key
+TOGETHER_API_KEY=your-together-api-key
+VERCEL_TOKEN=your-vercel-token
+VERCEL_ORG_ID=your-vercel-org-id
+NEXT_PUBLIC_APP_DOMAIN=your-app-domain.example.com
+SCREENSHOT_URL=https://your-app-domain.example.com
+BROWSERLESS_API_URL=https://playwright.example.com
+NEYNAR_API_KEY=your-neynar-api-key
+FARCASTER_BEARER_TOKEN=your-farcaster-bearer-token
+OPENROUTER_API_KEY=your-openrouter-api-key
+GEMINI_API_KEY=your-gemini-api-key
+AI_GATEWAY_API_KEY=your-ai-gateway-api-key
+CDP_API_KEY_ID=your-cdp-api-key-id
+CDP_API_KEY_SECRET=your-cdp-api-key-secret
+CDP_WALLET_SECRET=your-wallet-secret
+OPENAI_API_KEY=your-openai-api-key
+ZORA_API_KEY=your-zora-api-key
+NEXT_PUBLIC_BASE_CHAIN_ID=84532
+NEXT_PUBLIC_BASE_RPC_URL=https://sepolia.base.org
+PAYMASTER_URL=https://api.developer.coinbase.com/rpc/v1/base-sepolia/your-paymaster
+CDP_CLIENT_API_KEY=your-cdp-client-api-key
+CDP_RPC_URL_BASE_SEPOLIA=https://api.developer.coinbase.com/rpc/v1/base-sepolia/your-cdp-api-key
+CDP_RPC_URL_BASE=https://api.developer.coinbase.com/rpc/v1/base/your-cdp-api-key
+POSTGRES_URL=postgresql://user:password@host:5432/dbname?sslmode=require&channel_binding=require
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_your-clerk-publishable-key
+CLERK_SECRET_KEY=sk_test_your-clerk-secret-key
+CLERK_FRONTEND_API=https://your-clerk-frontend.accounts.dev
+NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
Add a .env.example file containing placeholder environment variables and update .gitignore to explicitly allow .env.example to be tracked.

This provides a safe, copy template for local configuration and prevents accidental commits of real secrets while including a reference of required env keys.